### PR TITLE
IMC: Added messages Altitude and Airflow

### DIFF
--- a/IMC.xml
+++ b/IMC.xml
@@ -2714,17 +2714,6 @@
     </field>
   </message>
 
-  <message id="290" name="Altitude" abbrev="Altitude" source="vehicle">
-    <description>
-      Report of Altitude.
-    </description>
-    <field name="Measured Altitude" abbrev="value" type="fp32_t" unit="m">
-      <description>
-        Altitude value measured by a sensor.
-      </description>
-    </field>
-  </message>
-
   <!-- Actuation -->
   <message id="300" name="Camera Zoom" abbrev="CameraZoom" source="vehicle">
     <description>

--- a/IMC.xml
+++ b/IMC.xml
@@ -2714,6 +2714,17 @@
     </field>
   </message>
 
+  <message id="290" name="Altitude" abbrev="Altitude" source="vehicle">
+    <description>
+      Report of Altitude.
+    </description>
+    <field name="Measured Altitude" abbrev="value" type="fp32_t" unit="m">
+      <description>
+        Altitude value measured by a sensor.
+      </description>
+    </field>
+  </message>
+
   <!-- Actuation -->
   <message id="300" name="Camera Zoom" abbrev="CameraZoom" source="vehicle">
     <description>
@@ -3640,6 +3651,22 @@
     <field name="Z component (Down)" abbrev="z" type="fp64_t" unit="m/s">
       <description>
         Z component (Down).
+      </description>
+    </field>
+  </message>
+
+  <message id="363" name="Airflow" abbrev="Airflow" source="vehicle">
+    <description>
+      Airflow angles.
+    </description>
+    <field name="Angle of attack" abbrev="aoa" type="fp32_t" unit="rad">
+      <description>
+        Angle of attack.
+      </description>
+    </field>
+    <field name="Sideslip angle" abbrev="ssa" type="fp32_t" unit="rad">
+      <description>
+        Sideslip angle.
       </description>
     </field>
   </message>

--- a/IMC.xml
+++ b/IMC.xml
@@ -3646,8 +3646,13 @@
 
   <message id="363" name="Airflow" abbrev="Airflow" source="vehicle">
     <description>
-      Airflow angles.
+      Airspeed along with airflow angles.
     </description>
+    <field name="Airspeed" abbrev="va" type="fp32_t" unit="m/s">
+      <description>
+        Airspeed, the 2-norm of the relative velocity.
+      </description>
+    </field>
     <field name="Angle of attack" abbrev="aoa" type="fp32_t" unit="rad">
       <description>
         Angle of attack.


### PR DESCRIPTION
We needed two different IMC messages for an Aeroprobe air data system. The first message is an airflow message that contains the angle of attack and sideslip angle. The second message is an altitude message.