### PR TITLE
Add XYZAQ type to SonarData

### DIFF
--- a/IMC.xml
+++ b/IMC.xml
@@ -2792,7 +2792,7 @@
 
       **XYZAQ:**
 
-      This type represents multibeam data in the form of XYZ-points (meters), with an amplitude/backscatter field (A) and a quality field (Q). This is similar to the BeamXYZA structure in the extended triton format (XTF). The number of points can be calculated by dividing the size of the data field by sizeof(uintX_t)*4 + sizeof(uint8_t).
+      This type represents multibeam data in the form of XYZ-points (meters), with an amplitude/backscatter field (A) and a quality field (Q). This is similar to the BeamXYZA structure in the extended triton format (XTF). The number of points can be calculated by dividing the size of the data field by sizeof(uintX_t)*4 + sizeof(uint8_t). If a C/C++ struct is used to represent the structure, ensure that no padding is present (#pragma pack(0)).
       
       +------+-------------------+----------------------+
       | Data | Name              | Type                 |

--- a/IMC.xml
+++ b/IMC.xml
@@ -2790,6 +2790,21 @@
 
          write(byte);
 
+      **XYZAQ:**
+
+      This type represents multibeam data in the form of XYZ-points (meters), with an amplitude/backscatter field (A) and a quality field (Q). This is similar to the BeamXYZA structure in the extended triton format (XTF). The number of points can be calculated by dividing the size of the data field by sizeof(uintX_t)*4 + sizeof(uint8_t).
+      
+      +------+-------------------+----------------------+
+      | Data | Name              | Type                 |
+      +======+===================+======================+
+      | A    | XYZAQ data        | uintX_t[4] + uint8_t |
+      +------+-------------------+----------------------+
+
+      .. figure:: ../images/imc_sidescan.png
+
+      * The type *uintX_t* will depend on the number of bits per unit, and it should be a multiple of 8.
+      * Furthermore, for now, 32 bits is the highest value of bits per unit supported.
+
       **Common:**
       
     </description>
@@ -2800,6 +2815,7 @@
       <value id="0" name="Sidescan" abbrev="SIDESCAN"/>
       <value id="1" name="Echo Sounder" abbrev="ECHOSOUNDER"/>
       <value id="2" name="Multibeam" abbrev="MULTIBEAM"/>
+      <value id="3" name="XYZAQ" abbrev="XYZAQ"/>
     </field>
     <field name="Frequency" abbrev="frequency" type="uint32_t" unit="Hz">
       <description>


### PR DESCRIPTION
I propose adding another entry to the SonarData type enumeration, which allows data on an XYZ-format. The change should be backwards compatible with existing codebases, provided that the enumeration value is unused. Within the existing IMC definition, I could fit this into the multibeam SonarData type by calculating the angles, but there is no field for the measurement quality. 

Another alternative would be to add a new message for generic point cloud or bathymetry data, with the possibility of specifying one or more additional scalars for each data point. There are the MapPoint/MapFeature messages, but they only represent a single point or feature with no possibility of adding additional data. 

I'm open for discussion on this. I will just use DevDataBinary if we cannot find a good solution. Feel free to reject the pull request if it does not fit into the scope of the SonarData message.