### PR TITLE
Add numeric vector type

### DIFF
--- a/IMC.xml
+++ b/IMC.xml
@@ -10,7 +10,7 @@
           xsi:noNamespaceSchemaLocation="IMC.xsd"
           name="IMC"
           long-name="Inter Module Communication"
-          version="5.4.11">
+          version="5.5.0">
 
   <description>
     This document describes the communications protocol associated
@@ -105,6 +105,11 @@
         Variable length ASCII character stream.
       </description>
     </type>
+    <type name="vector">
+      <description>
+        Variable length numerical container.
+      </description>
+    </type>
     <type name="message">
       <description>
         An inline message. Useful for encapsulating other messages.
@@ -144,6 +149,18 @@
         deserialization the prepended value is used to retrieve the
         correct ASCII character sequence size. The *plaintext* type
         length is limited only by the communication protocol in use.
+      </description>
+    </type>
+    <type name="vector">
+      <description>
+        A sequence of type *vector* is serialized by prepending a
+        value of type *uint16_t*, representing the number of elements
+        in the vector. On deserialization the prepended value is used 
+        to retrieve the number of bytes according to the specified
+        data type. The valid data types are integers and floating
+        point numbers, and specified using the *vector-type* attribute.
+        The *vector* type length is limited only by the communication 
+        protocol in use.
       </description>
     </type>
     <type name="message">

--- a/IMC.xsd
+++ b/IMC.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" version="5.0.0">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" version="5.1.0">
     <xs:annotation>
         <xs:documentation>
    ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -310,6 +310,7 @@
         </xs:attribute>
         <xs:attributeGroup ref="enumBitmaskRefAttributes"/>
         <xs:attributeGroup ref="messageTypeRefAttributes"/>
+        <xs:attributeGroup ref="vectorTypeRefAttributes"/>
     </xs:complexType>
     <xs:complexType name="headerType">
         <xs:sequence>
@@ -494,5 +495,8 @@
     </xs:attributeGroup>
     <xs:attributeGroup name="messageTypeRefAttributes">
         <xs:attribute name="message-type" type="xs:string" use="optional" default=""/>
+    </xs:attributeGroup>
+        <xs:attributeGroup name="vectorTypeRefAttributes">
+        <xs:attribute name="vector-type" type="xs:string" use="optional" default=""/>
     </xs:attributeGroup>
 </xs:schema>


### PR DESCRIPTION
Adds a variable-size container for numerical data to the spec. The container is serialized by prepending the data with an uint16_t declaring the number of **elements** that follows.

```xml
<message id="3000" name="Vector Test" abbrev="VectorTest" source="vehicle">
    <field name="X" abbrev="x" type="vector" vector-type="fp32_t"/>
</message>
```

I've also incremented the version of the specification and xml schema.